### PR TITLE
Add bookmarking functionality to venue details page

### DIFF
--- a/app/views/venues_templates/show.html.erb
+++ b/app/views/venues_templates/show.html.erb
@@ -62,7 +62,7 @@
                     </a>
 
                     <small class="float-right text-muted">
-                      about <%=(bookmark.updated_at)%> hour ago
+                      <%=time_ago_in_words(bookmark.created_at)%>
 
                       <a href="/bookmarks/<%=bookmark.id%>/edit">
                         <i class="fa fa-fw fa-edit"></i>
@@ -85,8 +85,9 @@
                   <input name="authenticity_token" type="hidden" value="LZLy8JGJqwRpwya/RxZBqdGf/xPLtOyi5N/jYIawvOoi8MmXchbHuuB5WklOTX52dPluVybVDIqXCuX/wh1fbA==">
 
 
-                  <input type="hidden" name="venue_id" value="110997">
-                  <input type="hidden" name="user_id" value="16629">
+                  <input type="hidden" name="venue_id" value=<%= @venue.id %>>
+                  <input type="hidden" name="user_id" value=<%=current_user.id %>>
+                  <input type="hidden" name="notes" value="">
 
                   <!-- Label and input for dish_id -->
                   <div class="form-group mr-sm-1">


### PR DESCRIPTION
This PR includes two changes to the venue details page for your review:

1. First (and most simply), adds the `time_ago_in_words` function to the displaying of when a bookmark was created using the `created_at` column.

2. Adds hidden input fields to the form used to create a bookmark and populates these dynamically using the current user and the current selected dish information.

Verify that this works by checking out this branch and doing some work around QA around being able to add different bookmarks from the venue details page.

@nevens05 @jeffmckee 