### PR TITLE
Latitudes and Longitudes for dev:prime task

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -128,6 +128,13 @@ namespace :dev do
       venue.name = venue_hash[:name]
       venue.address = venue_hash[:address]
       venue.neighborhood_id = neighborhood.try(:id)
+      url_safe_street_address = URI.encode(venue.address)
+      url = "https://maps.googleapis.com/maps/api/geocode/json?address="+url_safe_street_address+"&key=AIzaSyA5qwIlcKjijP_Ptmv46mk4cCjuWhSzS78"
+      raw_data = open(url).read
+      parsed_data = JSON.parse(raw_data)
+      f = parsed_data.fetch("results").at(0)
+      venue.address_latitude = f.fetch("geometry").fetch("location").fetch("lat")
+      venue.address_longitude = f.fetch("geometry").fetch("location").fetch("lng")
       venue.save
     end
 


### PR DESCRIPTION
An issue we've been having throughout testing is that none of the pre-populated data for venues we've been given has addresses, which makes it frustrating to test the mapping functionality. 

This PR modifies the task in order to ensure that all of the venues are given a latitude and longitude by querying the Google Maps API when the task is run. 

TODO: We should probably just hardcode those latitudes and longitudes to save the hits to the API each time, but for now just limit the number of times you run `rails dev:prime`.

Testing: Verify that this works by running rails dev:prime once on master branch and checking that none of the venues have associated latitudes and longitudes (i.e., go to `rails console` and do something like:

```
Venue.all.pluck("address_longitude").compact().count==27
Venue.all.pluck("address_latitude".compact().count==27 
```

@nevens05 @jeffmckee 